### PR TITLE
Fix for ImportError in newer Python versions (3.8+)

### DIFF
--- a/intermine/webservice.py
+++ b/intermine/webservice.py
@@ -13,7 +13,10 @@ try:
 except ImportError:
     from urllib.parse import urlparse
     from urllib.parse import urlencode
-    from collections import MutableMapping as DictMixin
+    try:
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        from collections.abc import MutableMapping as DictMixin
     from urllib.request import urlopen
 
 try:


### PR DESCRIPTION
from collections import MutableMapping as DictMixin
ImportError: cannot import name 'MutableMapping' from 'collections'