### PR TITLE
Modernize codebase for Python 3.10+

### DIFF
--- a/.github/workflows/im-build.yml
+++ b/.github/workflows/im-build.yml
@@ -30,10 +30,10 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '11'
-    - name: Set up python 3.10
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.13'
     - name: Change apt mirror
       run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ to enable wide-ranging and arbitrary queries.
 
 Requirements
 ------------
-This package is compatible with both Python 2.7 and 3.x. We plan to drop 2.7 support next year.
+This package requires Python 3.10 or higher.
 
 Downloading:
 ------------

--- a/intermine/bar_chart.py
+++ b/intermine/bar_chart.py
@@ -1,18 +1,14 @@
-from lxml import etree
 import json
-try:
-    import urllib.request as req
-except ImportError:
-    import urllib as req
-from lxml import etree
-
-from intermine.webservice import Service
+import urllib.request as req
 from math import log
-import json
-import requests
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import requests
+from lxml import etree
+
+from intermine.webservice import Service
 
 
 def save_mine_and_token(m, t):

--- a/intermine/idresolution.py
+++ b/intermine/idresolution.py
@@ -1,11 +1,6 @@
+import json
 import weakref
 import time
-
-# Use core json for 2.6+, simplejson for <=2.5
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 
 def get_json(service, path, key):

--- a/intermine/lists/list.py
+++ b/intermine/lists/list.py
@@ -1,14 +1,7 @@
 import weakref
 import logging
-
 import codecs
-
-try:
-    # Python 2.x imports
-    from urllib import urlencode
-except ImportError:
-    # Python 3.x imports
-    from urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from intermine.results import JSONIterator, EnrichmentLine
 from intermine.model import ConstraintNode

--- a/intermine/lists/listmanager.py
+++ b/intermine/lists/listmanager.py
@@ -1,49 +1,18 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import weakref
-import sys
 import logging
-
+import json
+import codecs
 from functools import partial
 from contextlib import closing
-
-# Use core json for 2.6+, simplejson for <=2.5
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
-try:
-
-    # Python 2.x imports
-
-    from urllib import urlencode
-except ImportError:
-
-    # Python 3.x imports
-
-    from urllib.parse import urlencode
-
-import urllib
-import codecs
+from urllib.parse import urlencode
 
 from intermine.errors import WebserviceError
 from intermine.lists.list import List
 
-P3K = sys.version_info >= (3, 0)
-
 logging.basicConfig()
-
-
-def safe_key(maybe_unicode):
-    if P3K:
-        return maybe_unicode  # that is fine
-
-    return maybe_unicode.decode('utf8')
 
 
 class ListManager(object):
@@ -102,10 +71,9 @@ class ListManager(object):
 
     @staticmethod
     def safe_dict(d):
-        """Recursively clone json structure with UTF-8 dictionary keys"""
-
+        """Clone dictionary (Python 2 compatibility shim, now just returns copy)"""
         if isinstance(d, dict):
-            return dict((safe_key(k), v) for (k, v) in d.items())
+            return dict(d)
         else:
             return d
 

--- a/intermine/model.py
+++ b/intermine/model.py
@@ -2,13 +2,9 @@ from xml.dom import minidom
 import weakref
 import re
 import logging
+from functools import reduce
 
 from intermine.util import openAnything, ReadableException
-
-try:
-    from functools import reduce
-except ImportError:
-    pass
 
 logging.basicConfig()
 

--- a/intermine/query.py
+++ b/intermine/query.py
@@ -10,10 +10,7 @@ from intermine.util import openAnything, ReadableException
 from intermine.pathfeatures import PathDescription, Join, SortOrder
 from intermine.pathfeatures import SortOrderList
 
-try:
-    from functools import reduce
-except ImportError:
-    pass
+from functools import reduce
 """
 Classes representing queries against webservices
 ================================================

--- a/intermine/query_manager.py
+++ b/intermine/query_manager.py
@@ -1,10 +1,8 @@
+import json
+import urllib.request as req
+
 import requests
 from lxml import etree
-import json
-try:
-    import urllib.request as req
-except ImportError:
-    import urllib as req
 """
 Functions for better usage of queries
 ================================================

--- a/intermine/results.py
+++ b/intermine/results.py
@@ -1,13 +1,8 @@
 try:
     import simplejson as json  # Prefer this as it is faster
-except ImportError:  # pragma: no cover
-    try:
-        import json
-    except ImportError:
-        raise ImportError("Could not find any JSON module to import - "
-                          + "please install simplejson or jsonlib to continue")
+except ImportError:
+    import json
 
-import urllib
 import re
 import copy
 import base64
@@ -15,29 +10,13 @@ import sys
 import logging
 from itertools import groupby
 from contextlib import closing
-
-P3K = sys.version_info >= (3, 0)
+from collections import UserDict
+from urllib.parse import urlencode, urlparse
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
+import http.client as httplib
 
 logging.basicConfig()
-
-try:
-    # Python 2.x imports
-    from UserDict import UserDict
-    from urllib import urlencode
-    from urllib2 import urlopen
-    from urllib2 import HTTPError
-    from urllib2 import Request
-    from urlparse import urlparse
-    import httplib
-except ImportError:
-    # Python 3.x imports
-    from urllib.parse import urlencode
-    from urllib.parse import urlparse
-    from urllib.request import urlopen
-    from urllib.request import Request
-    from urllib.error import HTTPError
-    from collections import UserDict
-    import http.client as httplib
 
 from intermine.errors import WebserviceError
 from intermine.model import Attribute, Reference, Collection

--- a/intermine/util.py
+++ b/intermine/util.py
@@ -1,9 +1,5 @@
-try:
-    from urllib import urlopen
-    from StringIO import StringIO
-except ImportError:
-    from urllib.request import urlopen
-    from io import StringIO
+from urllib.request import urlopen
+from io import StringIO
 
 
 def openAnything(source):

--- a/intermine/webservice.py
+++ b/intermine/webservice.py
@@ -1,23 +1,16 @@
-from __future__ import unicode_literals
-
 from xml.dom import minidom
 from contextlib import closing
 
 import requests
 
-from urllib.parse import urlparse
-from urllib.parse import urlencode
+from urllib.parse import urlparse, urlencode
 from collections.abc import MutableMapping as DictMixin
 from urllib.request import urlopen
 
 try:
     import simplejson as json  # Prefer this as it is faster
-except ImportError:  # pragma: no cover
-    try:
-        import json
-    except ImportError:
-        raise ImportError("Could not find any JSON module to import - "
-                          + "please install simplejson or jsonlib to continue")
+except ImportError:
+    import json
 
 # Local intermine imports
 from intermine.query import Query, Template

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,14 @@ The test and clean code is shamelessly stolen from
 http://da44en.wordpress.com/2002/11/22/using-distutils/
 """
 
-from __future__ import print_function
-
 import os
 import time
 import logging
-from distutils.core import Command, setup
+from setuptools import Command, setup
 from distutils import log
-from distutils.fancy_getopt import fancy_getopt
 from unittest import TextTestRunner, TestLoader
 from glob import glob
 from os.path import splitext, basename, join as pjoin
-import setuptools
-from distutils.core import setup
 
 from intermine import VERSION
 
@@ -30,8 +25,11 @@ OPTIONS = {
     'url': "http://www.intermine.org",
     'keywords': ["webservice", "genomic", "bioinformatics"],
     'classifiers': [
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
@@ -44,6 +42,7 @@ OPTIONS = {
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Operating System :: OS Independent",
     ],
+    'python_requires': '>=3.10',
     'license': "LGPL, BSD",
     'long_description': """\
 InterMine Webservice Client
@@ -164,7 +163,7 @@ class CleanCommand(Command):
         self.verbose = 0
 
     def finalize_options(self):
-        fancy_getopt(self.user_options, {}, self, None)
+        pass
 
     def run(self):
         for clean_me in self._files_to_delete:

--- a/tests/live_lists.py
+++ b/tests/live_lists.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from intermine.webservice import Service
 import os
 import sys

--- a/tests/live_results.py
+++ b/tests/live_results.py
@@ -1,34 +1,14 @@
-from __future__ import unicode_literals
-
-from intermine.errors import WebserviceError
-from intermine.webservice import Service
+from functools import reduce
 import unittest
 import sys
 import os
 import uuid
 import csv
+
+from intermine.errors import WebserviceError
+from intermine.webservice import Service
+
 sys.path.insert(0, os.getcwd())
-
-
-try:
-    from functools import reduce
-except ImportError:
-    pass  # py3k import.
-
-PY3K = sys.version_info >= (3, 0)
-
-
-def unicode_csv_reader(data, **kwargs):
-    """Only needed in py2.x"""
-    reader = csv.reader(utf_8_encoder(data), **kwargs)
-    for row in reader:
-        # Decode back.
-        yield [cell.decode('utf-8') for cell in row]
-
-
-def utf_8_encoder(unicode_data):
-    for line in unicode_data:
-        yield line.encode('utf-8')
 
 
 class LiveResultsTest(unittest.TestCase):
@@ -141,26 +121,14 @@ class LiveResultsTest(unittest.TestCase):
         self.assertManagerAgeIsSum('jsonrows', lambda row: row[0]['value'])
 
     def test_csv(self):
-        if PY3K:  # string handling differences
-            def parse(data): return csv.reader(
-                data, delimiter=',', quotechar='"')
-        else:
-            def parse(data): return unicode_csv_reader(
-                data, delimiter=b',', quotechar=b'"')
-
         results = self.manager_q.results(row='csv')
-        reader = parse(results)
+        reader = csv.reader(results, delimiter=',', quotechar='"')
         self.assertEqual(self.manager_age_sum, sum(
             int(row[0]) for row in reader))
 
     def test_tsv(self):
-        if PY3K:  # string handling differences
-            def parse(data): return csv.reader(data, delimiter='\t')
-        else:
-            def parse(data): return unicode_csv_reader(data, delimiter=b'\t')
-
         results = self.manager_q.results(row='tsv')
-        reader = parse(results)
+        reader = csv.reader(results, delimiter='\t')
         self.assertEqual(self.manager_age_sum, sum(
             int(row[0]) for row in reader))
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -2,17 +2,9 @@ import threading
 import time
 import os
 import posixpath
-import urllib
 from socket import socket
-
-try:
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
-    from BaseHTTPServer import HTTPServer
-    from urllib import unquote
-except ImportError:
-    from http.server import SimpleHTTPRequestHandler
-    from http.server import HTTPServer
-    from urllib.parse import unquote
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from urllib.parse import unquote
 
 
 class SilentRequestHandler(SimpleHTTPRequestHandler):  # pragma: no cover

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,8 +12,6 @@ from intermine.lists.list import List
 
 from tests.server import TestServer
 
-P3K = sys.version_info >= (3, 0)
-
 logging.basicConfig()
 
 
@@ -41,11 +39,6 @@ class WebserviceTest(unittest.TestCase):  # pragma: no cover
             except IOError as e:
                 self.do_unpredictable_test(test, attempts + 1, e)
             except Exception:
-                if not P3K:  # Handle connection reset errors
-                    e, t = sys.exc_info()[:2]
-                    if 104 in t:
-                        self.do_unpredictable_test(test, attempts + 1, t)
-                        return
                 raise
         else:
             raise RuntimeError("Max error count reached - last error: " + str(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,14 +1,10 @@
 import unittest
-import sys
-
 
 from intermine.webservice import *
 from intermine.query import Template
 from intermine.constraints import TemplateConstraint
 
 from tests.test_core import WebserviceTest
-
-P3K = sys.version_info >= (3, 0)
 
 
 class TestTemplates(WebserviceTest):  # pragma: no cover
@@ -25,14 +21,9 @@ class TestTemplates(WebserviceTest):  # pragma: no cover
         and get its results"""
         t = self.service.get_template("MultiValueConstraints")
         self.assertTrue(isinstance(t, Template))
-        if P3K:
-            expected = ("[<TemplateMultiConstraint: Employee.name ONE OF " +
-                        "['Dick', 'Jane', 'Timmy, the Loyal German-Shepherd']"
-                        " (editable, locked)>]")
-        else:
-            expected = ("[<TemplateMultiConstraint: Employee.name ONE OF "
-                        "[u'Dick', u'Jane', u'Timmy, the Loyal German-Shepherd']"
-                        " (editable, locked)>]")
+        expected = ("[<TemplateMultiConstraint: Employee.name ONE OF " +
+                    "['Dick', 'Jane', 'Timmy, the Loyal German-Shepherd']"
+                    " (editable, locked)>]")
         self.assertEqual(repr(list(t.editable_constraints)), expected)
 
     def testGetTemplateResults(self):


### PR DESCRIPTION
## Summary
- Migrate from deprecated `distutils` to `setuptools` (distutils was removed in Python 3.12)
- Remove all Python 2 compatibility code (try/except imports, `P3K` checks, `__future__` imports)
- Update CI to use Python 3.13
- Add `python_requires='>=3.10'` to setup.py
- Clean up duplicate imports and remove unused `safe_key()` function

## Breaking Change
Drops support for Python 2.7 and Python < 3.10

## Files Changed (18 files, -148 lines)
- `setup.py` - distutils → setuptools
- `intermine/*.py` - Python 3 imports only
- `intermine/lists/*.py` - Python 3 imports, removed `safe_key()`
- `tests/*.py` - Removed `P3K`/`PY3K` variables and Python 2 code paths
- `.github/workflows/im-build.yml` - Python 3.10 → 3.13
- `README.md` - Updated requirements

## Test plan
- [ ] All modified files pass `python3 -m py_compile`
- [ ] Run `python setup.py test` in a Python 3.10+ environment
- [ ] Run `python setup.py livetest` against a test InterMine instance